### PR TITLE
[수정] 품앗이(requests) Entity에 컬럼 3개 추가 및 1개 삭제

### DIFF
--- a/api.rest
+++ b/api.rest
@@ -20,6 +20,7 @@ POST http://localhost:3000/cats
 Content-Type: application/json
 
 {
+
     "name": "화이트",
     "gender": "수",
     "neutered": true,
@@ -34,7 +35,7 @@ GET http://localhost:3000/requests
 
 ###
 
-GET http://localhost:3000/requests/26
+GET http://localhost:3000/requests/11
 
 ###
 
@@ -43,8 +44,9 @@ Content-type: application/json
 # Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjMwLCJlbWFpbCI6InRlc3Q0QGdtYWlsLmNvbSIsImlhdCI6MTY3ODYzNzIyNCwiZXhwIjoxNjc4NzIzNjI0fQ.-bmWharYBe6bLHJIpWkyd20owP2jng7KZdZC0bE9Ce8
 
 {
-    "reserved_time": "2023-04-23",
-    "detail": "순한 고양이 품앗이 부탁드려요"
+    "reserved_begin_date": "2023-04-27",
+    "reserved_end_date": "2023-04-27",
+    "detail": "reserved_time => reserved_begin/end_date으로 변경했습니다. 잘 되는지 우선 Rest Client 테스트 중. "
 }
 
 ###
@@ -52,7 +54,8 @@ PATCH http://localhost:3000/requests/23
 Content-Type: application/json
 
 {
-    "reserved_time": "2023-04-01",
+    "reserved_begin_date": "2023-04-01",
+    "reserved_end_date": "2023-04-01",
     "detail": "냥품 요청합니다~ new3!!"
 }
 

--- a/src/config/typeorm.config.service.ts
+++ b/src/config/typeorm.config.service.ts
@@ -39,7 +39,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         Products,
         ProductsTradeLocation,
       ],
-      synchronize: false, // true
+      synchronize: false, // true,
       logging: ['error'],
       autoLoadEntities: true,
       namingStrategy: new SnakeNamingStrategy(),

--- a/src/requests/dto/create-request.dto.ts
+++ b/src/requests/dto/create-request.dto.ts
@@ -5,5 +5,8 @@ export class CreateRequestDto {
   readonly detail: string;
 
   @IsDateString()
-  readonly reserved_time: Date;
+  readonly reserved_begin_date: Date;
+
+  @IsDateString()
+  readonly reserved_end_date: Date;
 }

--- a/src/requests/dto/update-request.dto.ts
+++ b/src/requests/dto/update-request.dto.ts
@@ -1,4 +1,8 @@
 import { PartialType } from '@nestjs/mapped-types';
+import { IsBoolean } from 'class-validator';
 import { CreateRequestDto } from './create-request.dto';
 
-export class UpdateRequestDto extends PartialType(CreateRequestDto) {}
+export class UpdateRequestDto extends PartialType(CreateRequestDto) {
+  @IsBoolean()
+  readonly is_ongoing?: Boolean;
+}

--- a/src/requests/request.entity.ts
+++ b/src/requests/request.entity.ts
@@ -22,7 +22,13 @@ export class Request {
   detail: string;
 
   @Column('date')
-  reserved_time: Date;
+  reserved_begin_date: Date;
+
+  @Column('date')
+  reserved_end_date: Date;
+
+  @Column('boolean', { default: true })
+  is_ongoing: Boolean;
 
   @CreateDateColumn()
   created_at: Date;

--- a/views/RequestDetail.ejs
+++ b/views/RequestDetail.ejs
@@ -73,7 +73,7 @@
 
 	<div class="request-detail-container" >
 		<% 		
-		const minutesAgo = (Date.now() - new Date(request.updated_at)) / 1000 / 60
+		const minutesAgo = (Date.now() - new Date(request.updated_at)) / 1000 / 60 - (60 * 9)
 		let updated = ''
 		if (minutesAgo < 60) {
 			updated += parseInt(minutesAgo) + '분'
@@ -82,13 +82,19 @@
 		} else {
 			updated += minutesAgo / 60 / 24 + '일'
 		} 
+		let reserved_dates = ''
+		if (request.reserved_end_date == request.reserved_begin_date) {
+			reserved_dates = request.reserved_begin_date;
+		} else {
+			reserved_dates = request.reserved_begin_date + ' ~ ' + request.reserved_end_date;
+		}
 		%>
 
 		<div class="col">
 			<div class="card h-100">
 				<div class="card-header">집사 정보</div>
 				<div class="card-body">
-					<p class="card-title">돌봄이 필요한 기간: <%= request.reserved_time %></p>
+					<p class="card-title">돌봄이 필요한 기간: <%= reserved_dates %></p>
 					<p class="card-title">닉네임: <%= request.user.nickname %></p>
 					<p class="card-title">동네: <%= request.request_id %></p>
 				</div>

--- a/views/basicHeader.ejs
+++ b/views/basicHeader.ejs
@@ -20,7 +20,7 @@
         </div>
       <%} else { %>
         <ul class="navbarMenu">
-          <li><a href="/">품앗이 신청</a></li>
+          <li><a href="/request/list">품앗이 신청</a></li>
           <li><a href="/">냥품나눔</a></li>
           <li><a href="/">자유게시판</a></li>
         </ul>

--- a/views/main.ejs
+++ b/views/main.ejs
@@ -30,8 +30,14 @@
       <div class="slideWarpper1">
         <ul class="slides1">
           <% for (let i = 0; i < requests.length; i++) {
-            console.log(requests[1]);
-            const request = requests[i]; %>
+            const request = requests[i]; 
+            let reserved_dates = ''
+            if (request.reserved_end_date == request.reserved_begin_date) {
+              reserved_dates = request.reserved_begin_date;
+            } else {
+              reserved_dates = request.reserved_begin_date + ' ~ ' + request.reserved_end_date;
+            }
+            %>
             <li class="catCard">
               <div class="imgContainer" style="background-image: url('<%= request.user.cats[0].image %>');">
                 <img src="" alt="">
@@ -44,7 +50,7 @@
                   기간
                 </div>
                 <div class="periodDetail">
-                  <%= request.reserved_time %> ~ 0000년00월00일
+                  <%= reserved_dates %>
                 </div>
               </div>
               <div class="infoContainer">

--- a/views/mainHeader.ejs
+++ b/views/mainHeader.ejs
@@ -20,7 +20,7 @@
           </div>
         <%} else{%>
           <ul class="navbarMenu">
-            <li><a href="/">품앗이 신청</a></li>
+            <li><a href="/request/list">품앗이 신청</a></li>
             <li><a href="/">냥품나눔</a></li>
             <li><a href="/">자유게시판</a></li>
           </ul>

--- a/views/requestList.ejs
+++ b/views/requestList.ejs
@@ -22,15 +22,24 @@
 			<% for (let i = 0; i < 8; i++) { 
 				console.log(requests[1]);
 				const request = requests[i]; 
-				const minutesAgo = (Date.now() - new Date(request.updated_at)) / 1000 / 60
-					let updated = ''
-					if (minutesAgo < 60) {
-						updated += parseInt(minutesAgo) + '분'
-					} else if (minutesAgo / 60 <= 48) {
-						updated += parseInt(minutesAgo / 60) + '시간'
-					} else {
-						updated += minutesAgo / 60 / 24 + '일'
-					} %>
+				const minutesAgo = (Date.now() - new Date(request.updated_at)) / 1000 / 60 - (60 * 9)
+				let updated = ''
+				if (minutesAgo < 60) {
+					updated += parseInt(minutesAgo) + '분'
+				} else if (minutesAgo / 60 <= 48) {
+					updated += parseInt(minutesAgo / 60) + '시간'
+				} else {
+					updated += minutesAgo / 60 / 24 + '일'
+				} 
+
+				let reserved_dates = ''
+				if (request.reserved_end_date == request.reserved_begin_date) {
+					reserved_dates = request.reserved_begin_date;
+				} else {
+					reserved_dates = request.reserved_begin_date + ' ~ ' + request.reserved_end_date;
+				}
+				%>
+
 				<div class="col">
 					<div class="card h-100" style="border-radius: 20px">
 
@@ -46,7 +55,7 @@
 									기간
 								</div>
 								<div class="cat-info-content">
-									<%= request.reserved_time %>
+									<%= reserved_dates %> 
 								</div>
 							</div>
 							<div class="whole-column-container">

--- a/views/requestPost.ejs
+++ b/views/requestPost.ejs
@@ -1,48 +1,63 @@
-<!-- 품앗이 요청 작성 페이지입니다!
-페이지 Body부분에 보여지는 코드입니다. <Body></Body> 생략하시고 시작해주세요! -->
 
 <div class="justify-content-center" style="width: 80%; max-width: 560px;">
     
   <div class="input-group mb-3">
 	<span class="input-group-text">기간 선택</span>
-	<input type="date" class="form-control" placeholder="Username" aria-label="Username">
+	<input type="date" id="start-date" class="form-control" placeholder="Username" aria-label="Username">
 	<span class="input-group-text"> ~ </span>
-	<input type="date" class="form-control" placeholder="Server" aria-label="Server">
+	<input type="date" id="end-date" class="form-control" placeholder="Server" aria-label="Server">
   </div>
   
   <div class="col-md-2">
 	<span class="input-group-text"> 상세 요청 </span>
   </div>
   <div class="form-floating">
-	<textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2" style="height: 250px"></textarea>
-	<label for="floatingTextarea2">Comments</label>
+	<textarea id="detail" class="form-control" placeholder="Leave a comment here" id="floatingTextarea2" style="height: 250px"></textarea>
+	<label for="floatingTextarea2">요청시 특이 사항과 상세 설명을 작성해주세요(500자 이내)</label>
   </div>
-  <!-- <div class="col-md-6">
-    <label for="inputEmail4" class="form-label">Email</label>
-    <input type="email" class="form-control" id="inputEmail4">
+
+  <div class="d-flex">
+	<button onclick="createRequest()" type="button" class="btn btn-outline-dark">제출</button>
+	<button onclick="location.href='/request/list'" type="button" class="btn btn-outline-secondary">취소</button>
   </div>
-  <div class="col-md-6">
-    <label for="inputPassword4" class="form-label">Password</label>
-    <input type="password" class="form-control" id="inputPassword4">
-  </div> -->
-<div class="row row-md-9">
-  <div class="col-md-3">
-	<span class="input-group-text"> 기간 선택 </span>
-  </div>
-  <div class="col-md-4">
-	<input type="date" class="form-control" placeholder="부터"></textarea>
-  </div>
-  <div class="col-md-1">
-	-
-	</div>
-  <div class="col-md-4">
-	<input type="date" class="form-control" placeholder="까지"></textarea>
-  </div>
+
 </div>
 
-  <div class="input-group">
-	<span class="input-group-text">상세 요청 사항</span>
-	<textarea class="form-control" aria-label="With textarea" style="height:300px"></textarea>
-  </div>
+<script>
+	async function createRequest() {
+		const startDate = $('#start-date').val()
+		const endDate = $('#end-date').val()
+		const detail = $('#detail').val()
 
-</div>  
+		if (!startDate) {
+			alert('시작 날짜를 입력해주세요')
+			return;
+		}
+		if (!endDate) {
+			alert('끝 날짜를 입력해주세요')
+			return;
+		}
+		if (!detail) {
+			alert('상세 요청 사항을 입력해주세요')
+			return;
+		}
+
+		$.ajax({
+			type: 'POST',
+			url: '/requests',
+			data: {
+				reserved_begin_date: startDate,
+				reserved_end_date: endDate,
+				detail,
+			},
+			success: function (response) {
+				alert('게시글 작성을 완료하였습니다')
+				location.href = '/request/list';
+			},
+			error: function (response) {
+				console.log(response);
+				console.log(response.responseJSON.message);
+			}
+		})
+	}
+</script>


### PR DESCRIPTION
[수정] 품앗이(requests) Entity에 컬럼 3개 추가 및 1개 삭제

    - reserved_time 컬럼 삭제
    - reserved_begin_date과 reserved_end_date추가 (품앗이 신청 희망 기간의 시작과 끝을 저장하기 위함)
    - is_ongoing 컬럼 추가 (true: 모집중, false: 모집 마감)

[추가] 품앗이 신청 작성 페이지 requestPost.ejs 완성
[수정] 품앗이 목록(requestList.ejs)와 품앗이 상세 조회 페이지(requestDetail.ejs)에서 '00분 전 업데이트' 계산 오류 수정 완료
[추가] 품앗이 목록 페이지에 '작성하러 가기' 버튼 추가 및 자잘한 수정 완료