### PR TITLE
[추가] https 인증서와 개인키 발급을 위한 mkcert 라이브러리 설치

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@ lerna-debug.log*
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# custom
 .env
+*.crt
+*.key

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -84,6 +84,7 @@ export class AppModule implements NestModule {
       { path: 'users/admin', method: RequestMethod.ALL },
       { path: 'users/admin/member', method: RequestMethod.ALL },
       { path: 'users/admin/member/:id', method: RequestMethod.ALL },
+      { path: 'users/address/certify', method: RequestMethod.PATCH },
       { path: 'cats', method: RequestMethod.ALL },
       { path: 'cats/:id', method: RequestMethod.PATCH },
       { path: 'messages', method: RequestMethod.POST },

--- a/src/ejs-render/ejs-render.controller.ts
+++ b/src/ejs-render/ejs-render.controller.ts
@@ -14,13 +14,15 @@ import { PostsService } from 'src/posts/posts.service';
 import { RequestsService } from 'src/requests/requests.service';
 import { MessagesService } from 'src/messages/messages.service';
 import { ProductsService } from 'src/share-modules/share-products/share-products.service';
+import { ConfigService } from '@nestjs/config';
 @Controller()
 export class EjsRenderController {
   constructor(
     private readonly requestsService: RequestsService,
     private readonly postsService: PostsService,
     private readonly messagesService: MessagesService,
-    private readonly productsService: ProductsService
+    private readonly productsService: ProductsService,
+    private readonly configService: ConfigService
   ) {}
 
   @Get('/')
@@ -43,7 +45,8 @@ export class EjsRenderController {
   @Get('/mypage')
   @Render('index')
   myPage(@Req() req) {
-    return { components: 'myPage', userId: req.userId, user: req.user };
+    const KAKAO_APP_KEY = this.configService.get<string>('KAKAO_APP_KEY');
+    return { components: 'myPage', userId: req.userId, KAKAO_APP_KEY };
   }
 
   @Get('')

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,4 +51,5 @@ async function bootstrap() {
     console.log('3000번 포트로 서버가 열렸습니다. https://localhost:3000');
   });
 }
+
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,16 @@ import { ConfigService } from '@nestjs/config';
 import basicAuth from 'express-basic-auth';
 import { setupSwagger } from './config/swagger.config.service';
 import cookieParser from 'cookie-parser';
+import * as fs from 'fs';
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  const httpsOptions = {
+    key: fs.readFileSync('src/config/cert.key'),
+    cert: fs.readFileSync('src/config/cert.crt'),
+  };
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    httpsOptions,
+  });
   app.useGlobalPipes(new ValidationPipe());
   app.useGlobalFilters(new HttpExceptionFilter());
 
@@ -40,6 +47,8 @@ async function bootstrap() {
     credentials: true,
   });
 
-  await app.listen(3000);
+  await app.listen(3000, () => {
+    console.log('3000번 포트로 서버가 열렸습니다. https://localhost:3000');
+  });
 }
 bootstrap();

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -8,7 +8,9 @@ export class CreateUserDto {
   @IsString()
   readonly email: string;
   @IsString()
-  readonly address: string;
+  readonly address_road: string;
+  @IsString()
+  readonly address_bname: string;
   @IsString()
   readonly phone_number: string;
   @IsString()

--- a/src/users/dto/update-address-certified.dto.ts
+++ b/src/users/dto/update-address-certified.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class UpdateAddressCertifiedDto {
+  @IsBoolean()
+  readonly address_certified: boolean;
+}

--- a/src/users/dto/update-member-info.dto.ts
+++ b/src/users/dto/update-member-info.dto.ts
@@ -3,7 +3,8 @@ import { CreateUserDto } from './create-user.dto';
 
 export class UpdateMypageDto extends PartialType(CreateUserDto) {
   nickname?: string;
-  address?: string;
+  address_road?: string;
+  address_bname?: string;
   phone_number?: string;
   password?: string;
 }

--- a/src/users/dto/update-mypage.dto.ts
+++ b/src/users/dto/update-mypage.dto.ts
@@ -1,9 +1,13 @@
 import { PartialType } from '@nestjs/mapped-types';
+import { IsBoolean } from 'class-validator';
 import { CreateUserDto } from './create-user.dto';
 
 export class UpdateMypageDto extends PartialType(CreateUserDto) {
   nickname?: string;
-  address?: string;
+  address_road?: string;
+  address_bname?: string;
+  @IsBoolean()
+  address_certified?: boolean;
   phone_number?: string;
   password?: string;
 }

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -38,7 +38,13 @@ export class User {
   email: string;
 
   @Column('varchar', { length: 50 })
-  address: string;
+  address_road: string;
+
+  @Column('varchar', { length: 50 })
+  address_bname: string;
+
+  @Column('boolean', { default: false })
+  address_certified: Boolean;
 
   @Column('varchar', { length: 20 })
   phone_number: string;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -14,6 +14,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateMypageDto } from './dto/update-mypage.dto';
 import { UsersService } from './users.service';
 import { UpdateMemberDto } from './dto/update-member-status.dto';
+import { UpdateAddressCertifiedDto } from './dto/update-address-certified.dto';
 
 @Controller('users')
 export class UsersController {
@@ -88,5 +89,14 @@ export class UsersController {
   async getUserId(@Body() email) {
     const a = await this.usersService.findOneByEmail(email.email);
     return a.user_id;
+  }
+
+  // 유저의 '위치(동네) 인증' 처리: address_certified을 false -> true로 변경
+  @Patch('address/certify')
+  updateAddressCertified(
+    @Req() req,
+    @Body() isCertified: UpdateAddressCertifiedDto
+  ) {
+    this.usersService.updateAddressCertified(req.userId, isCertified);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -13,6 +13,7 @@ import * as bcrypt from 'bcrypt';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UpdateMypageDto } from './dto/update-mypage.dto';
 import { UpdateMemberDto } from './dto/update-member-status.dto';
+import { UpdateAddressCertifiedDto } from './dto/update-address-certified.dto';
 
 @Injectable()
 export class UsersService {
@@ -85,7 +86,9 @@ export class UsersService {
         'email',
         'name',
         'nickname',
-        'address',
+        'address_road',
+        'address_bname',
+        'address_certified',
         'phone_number',
         'status',
       ],
@@ -96,10 +99,18 @@ export class UsersService {
   async updateUserById(id: number, userId: number, bodyData: UpdateMypageDto) {
     const user = await this.findUser(id);
     if (user.user_id === Number(userId)) {
-      const { nickname, address, phone_number } = bodyData;
+      const {
+        nickname,
+        address_road,
+        address_bname,
+        address_certified,
+        phone_number,
+      } = bodyData;
       await this.userRepository.update(id, {
         nickname,
-        address,
+        address_road,
+        address_bname,
+        address_certified,
         phone_number,
       });
       return '회원정보 수정이 완료되었습니다.';
@@ -181,5 +192,23 @@ export class UsersService {
       select: ['user_id', 'status'],
     });
     return user;
+  }
+
+  /* 
+    유저의 현재 위치의 '동네명'이 회원 가입 시 등록한 주소의 '동네명'과 일치 또는
+    현재 위치 좌표와 회원 가입시 등록한 '도로명' 주소로 찾은 좌표 사이 거리가 1km 내라면
+    동네(위치) 인증으로 처리 
+    프론트에서 위의 로직이 실행되며 이 API는 호출시 단순히 위치 인증 여부 컬럼
+    (user.address_certified)을 '참'으로 변경함
+  */
+  updateAddressCertified(id: number, isCertified: UpdateAddressCertifiedDto) {
+    const { address_certified } = isCertified;
+    console.log(
+      'inside user.service, isCertified boolean? ',
+      address_certified,
+      'id: ',
+      id
+    );
+    this.userRepository.update(id, { address_certified });
   }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -24,8 +24,6 @@
 
   <!-- JS -->
   <script defer type="text/javascript" src="/js/main/main.js"></script>
-  <script defer type="text/javascript" src="/js/shareProduct/shareProduct.js"></script>
-  <script defer type="text/javascript" src="/js/shareProduct/shareList.js"></script>
   
   <!-- jquery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>

--- a/views/myPage.ejs
+++ b/views/myPage.ejs
@@ -1,5 +1,11 @@
 <script defer type="text/javascript" src="/js/myPage/myPage.js"></script>
 
+<!-- 다음 우편번호 찾기 API -->
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+
+<!-- Kakao Map API -->
+<script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%= KAKAO_APP_KEY %>&libraries=services" type="text/javascript"></script>
+
 <div class="title">
     마이 페이지
   </div>

--- a/views/public/js/myPage/myPage.js
+++ b/views/public/js/myPage/myPage.js
@@ -33,7 +33,7 @@ function showMyPage() {
             <input value="${response.address_road}" class="infoContent1" type="text" id="address_road" placeholder="주소" readonly>
             <input value="${response.address_bname}" class="infoContent1" type="text" id="address_bname" placeholder="동" readonly>
             <input type="button" onclick="findAddress()" class="btn btn-outline-secondary" value="주소 검색"><br>
-            </div>
+          </div>
           <div class="">
             <li class="miniTitle">동네 인증 상태</li>
             <input value="${addressCertified}" class="infoContent1" type="text" id="address_certified" placeholder"위치 인증 여부" readonly>

--- a/views/public/js/myPage/myPage.js
+++ b/views/public/js/myPage/myPage.js
@@ -1,3 +1,6 @@
+
+let user;
+
 $(document).ready(
   function() {
     showMyPage(),
@@ -10,7 +13,10 @@ function showMyPage() {
     type: 'GET',
     url: 'users/mypage',
     data: {},
-    success: function(response) {
+    success: function (response) {
+      user = response;
+      let addressCertified = response.address_certified == 1 ? '인증됨' : '인증 안됨';
+
       let tempHtml = `      
       <div class="lineContainer">
         <ul class="line">
@@ -24,7 +30,14 @@ function showMyPage() {
           </div>
           <div class="subLine">
             <li class="miniTitle">주소</li>
-            <input value="${response.address}" class="infoContent1" id="address" type="text">
+            <input value="${response.address_road}" class="infoContent1" type="text" id="address_road" placeholder="주소" readonly>
+            <input value="${response.address_bname}" class="infoContent1" type="text" id="address_bname" placeholder="동" readonly>
+            <input type="button" onclick="findAddress()" class="btn btn-outline-secondary" value="주소 검색"><br>
+            </div>
+          <div class="">
+            <li class="miniTitle">동네 인증 상태</li>
+            <input value="${addressCertified}" class="infoContent1" type="text" id="address_certified" placeholder"위치 인증 여부" readonly>
+            <button onclick="verifyLocation()" type="button" class="btn btn-outline-success">내 위치로 동네 인증하기</button>
           </div>
         </ul> 
         <ul class="line" id="line3">
@@ -50,8 +63,22 @@ function showMyPage() {
 
 function modifyMyPage(id) {
   const nickname = $('#nickname').val();
-  const address = $('#address').val();
+  const address_road = $('#address_road').val();
+  const address_bname = $('#address_bname').val();
   const phone_number = $('#phoneNumber').val();
+  let address_certified = $('#address_certified').val() == '인증됨';
+  console.log('현재 인증 상태: ', address_certified)
+
+  // 주소를 변경하겠다는 상태라면
+  if (user.address_road !== address_road) {
+    const yesChangeAddress = confirm('주소 변경시 동네 인증을 다시 해야 합니다. 주소를 변경하시겠습니까? ')
+    if (yesChangeAddress) {
+      address_certified = false;
+    } else {
+      return;
+    }
+  }
+  
   $.ajax({
     type: 'PATCH',
     url: `users/mypage/${id}`,
@@ -59,11 +86,14 @@ function modifyMyPage(id) {
     contentType: 'application/json; charset=utf-8',
     async: false,
     data: JSON.stringify({
-      nickname: nickname,
-      address: address,
-      phone_number: phone_number
+      nickname,
+      address_road,
+      address_bname,
+      address_certified,
+      phone_number,
     }),
-    success: function(response) {
+    success: function (response) {
+      alert('회원 정보 수정이 완료되었습니다')
       window.location.reload()
     },
     error: function(response) {
@@ -230,3 +260,128 @@ function deleteMyCat(id) {
     }
   })
 }
+
+
+// '주소 검색' 버튼 클릭시 다음 우편번호 찾기 api로 주소 검색
+function findAddress() {
+  new daum.Postcode({
+      oncomplete: function(data) {
+          var address_road = data.address; // 최종 도로명 주소
+          var address_bname = data.bname? data.bname : ''; // 동 (지번주소)
+
+          // 주소 정보를 해당 필드에 넣는다.
+          document.getElementById("address_road").value = address_road;
+          document.getElementById("address_bname").value = address_bname;
+      }
+  }).open();
+}
+
+// '내 위치로 동네 인증' 버튼 클릭시 사용자의 현재 위치를 얻어와 주소지와 비교,
+// 동네명이 같거나 기록된 주소<->현재위치 거리가 1km 이내라면 동네 인증 처리
+async function verifyLocation() {
+
+  //주소-좌표 변환 객체를 생성
+  var geocoder = new daum.maps.services.Geocoder();
+
+  // 유저의 도로명 주소와 동네명을 불러온다 -> DB에서 직접 불러오는 것으로 변경
+  let userAddress = user.address_road
+  let userAddressBname = user.address_bname;  
+  
+  // 새 주소찾기를 하였지만 아직 수정 버튼을 눌러 DB를 업데이트하지 않은 상황이면
+  if (user.address_road != document.getElementById('address_road').value) { 
+    alert('수정 버튼을 눌러 정보 업데이트 후 진행해주세요');
+    return;
+  }
+
+  // geolocation.getCurrentPosition 성공시 콜백
+  function success(position) {
+    
+    // 유저의 현재 GPS 위치를 불러온다
+    const { latitude, longitude } = position.coords;
+    
+    // kakao map api를 이용하여 두 좌표 사이의 거리 측정하기
+    geocoder.addressSearch(userAddress, function(results, status) {
+      if (status === daum.maps.services.Status.OK) {
+        let result = results[0];
+
+        // 주소로 검색해 kakao map 좌표 객체를 얻고
+        var userAddressCoords = new daum.maps.LatLng(result.y, result.x);
+        // 현재 좌표로 kakao map 좌표 객체를 얻어서
+        var userCurrentCoords = new daum.maps.LatLng(latitude, longitude);
+
+        // 두 좌표를 경로로 하는 폴리라인 설정
+        var line = new kakao.maps.Polyline();
+        var path = [ userAddressCoords, userCurrentCoords ];
+        line.setPath(path);
+
+        console.log('두 좌표 사이의 거리: ', line.getLength())
+        
+        const isInRadius = line.getLength() <= 1000
+        alert(`위치 인증을 마쳤습니다. 결과는 ${isInRadius}입니다`)
+
+
+        // kakao map api를 이용하여 두 좌표의 동네명 비교하기
+        geocoder.coord2Address(longitude, latitude, function (results, status) {
+          if (status === daum.maps.services.Status.OK) {
+            let result = results[0];
+            console.log("현재 좌표 기반 주소찾기 결과: ", result);
+    
+            // 현재 좌표로 동네명 얻기
+            var userCurrentBname = result.address.region_3depth_name;
+            console.log('현재 동네명: ', userCurrentBname)
+    
+            const isSameBname = userCurrentBname == userAddressBname
+            alert(`동네 인증을 마쳤습니다. ${isSameBname}입니다`)
+
+
+            // 동네명이 같거나 기록된 주소<->현재위치 거리가 1km 이내라면 
+            // 사용자의 address_certified 컬럼을 true로 변환시키는 ajax 콜 호출
+              console.log('isSameBname, isInRadius: ', isSameBname, isInRadius)
+              if (isSameBname || isInRadius) {
+                alert('사용자 정보를 변경합니다');
+                $.ajax({
+                  type: 'PATCH',
+                  url: `users/address/certify`,
+                  contentType: 'application/json; charset=utf-8',
+                  data: JSON.stringify({
+                    address_certified: true,
+                  }),
+                  success: function (response) {
+                    alert('회원 정보 수정이 완료되었습니다')
+                    window.location.reload()
+                  },
+                  error: function(response) {
+                    console.log(response)
+                  }
+                })
+              }
+
+          } else {
+            console.log('geocoder.coord2Address 도중 문제가 생겼습니다. 상태코드: ', status);
+            return;
+          }
+        })
+
+      } else {
+        console.log('geocoder.addressSearch 도중 문제가 생겼습니다. 상태코드: ', status);
+        return;
+      }
+    })
+    
+  }
+
+  // geolocation.getCurrentPosition 실패시 콜백
+  function error() {
+    alert('위치 정보를 불러올 수 없습니다.');
+  }
+
+  // 실행 가능한 환경이라면 geolocation으로 사용자의 현재 좌표 정보에 접근 
+  if(!navigator.geolocation) {
+    alert('현재 브라우저로는 위치 서비스를 이용하실 수 없습니다. 다른 브라우저로 접속하거나 운영자에게 문의해주세요.');
+  } else {
+    alert('위치 정보를 성공적으로 불러옵니다')
+    return navigator.geolocation.getCurrentPosition(success, error);
+  }
+}
+
+

--- a/views/requestPost.ejs
+++ b/views/requestPost.ejs
@@ -3,6 +3,7 @@
 	<div class="d-flex justify-content-center">
 		<h1 class="text-center">품앗이 지원</h1>
 	</div>
+	<br/>
 
   <div class="input-group mb-3">
 	<span class="input-group-text">기간 선택</span>

--- a/views/shareList.ejs
+++ b/views/shareList.ejs
@@ -5,6 +5,8 @@
   href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800&display=swap"
   rel="stylesheet"
 />
+<script defer type="text/javascript" src="/js/shareProduct/shareList.js"></script>
+
 <!-- 나눔 게시판 페이지입니다!
 페이지 Body부분에 보여지는 코드입니다. <Body></Body> 생략하시고 시작해주세요! -->
 <nav class="sp_nav">

--- a/views/shareProduct.ejs
+++ b/views/shareProduct.ejs
@@ -1,8 +1,5 @@
 <link rel="stylesheet" href="/css/shareProduct/shareProduct.css" />
-<!-- 나눔 게시글 작성 페이지입니다!
-
-
-페이지 Body부분에 보여지는 코드입니다. <Body></Body> 생략하시고 시작해주세요! -->
+<script defer type="text/javascript" src="/js/shareProduct/shareProduct.js"></script>
 
 <nav class="sp_nav">
   <a class="sp_nav-link" href="/shareList">상품조회</a>

--- a/views/signUp.ejs
+++ b/views/signUp.ejs
@@ -1,6 +1,6 @@
-<!-- 회원가입 페이지입니다!
-페이지 Body부분에 보여지는 코드입니다. <Body></Body> 생략하시고 시작해주세요! -->
-<!-- styles -->
+
+<!-- 다음 우편번호 찾기 API -->
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 
 <body>
     <section>
@@ -25,16 +25,20 @@
                 <button onclick="check()" class="btn btn-outline-primary" type="button">인증</button>
             </div>	
             <div class="form-group mt-2">
-                <input type="password" name="signupPass" class="form-style" placeholder="Your Password" id="signupPass" autocomplete="off">
+                <input type="password" name="signupPass" class="form-style" placeholder="비밀번호" id="signupPass" autocomplete="off">
             </div>
             <div class="form-group mt-2">
                 <input type="text" name="signupAddress" class="form-style" placeholder="Your Address" id="signupAddress" autocomplete="off">
+                <li class="miniTitle">주소</li>
+                <input class="form-style" type="text" value="" id="signupAddressRoad" placeholder="도로명" readonly>
+                <input class="form-style" type="text" value="" id="signupAddressBname" placeholder="동" readonly>
+                <input type="button" onclick="findAddress()" class="btn btn-outline-secondary" value="주소 검색"><br>
             </div>
             <div class="form-group mt-2">
-                <input type="tel" name="signupPhonenumber" class="form-style" placeholder="Your Phone" id="signupPhonenumber" autocomplete="off">
+                <input type="tel" name="signupPhonenumber" class="form-style" placeholder="핸드폰 번호" id="signupPhonenumber" autocomplete="off">
             </div>
             <div class="form-group mt-2">
-                <input type="text" name="signupReferralcode" class="form-style" placeholder="Your referral_code" id="signupReferralcode" autocomplete="off">
+                <input type="text" name="signupReferralcode" class="form-style" placeholder="추천인 코드" id="signupReferralcode" autocomplete="off">
             </div>
             
             <button onclick="signUp()" id="target_btn" disabled="disabled" class="btn btn-outline-primary" type="button">signup</button>
@@ -97,12 +101,28 @@
         }
         
     }
+    
+    // '주소 검색' 버튼 클릭시 다음 우편번호 찾기 api로 주소 검색
+    function findAddress() {
+        new daum.Postcode({
+            oncomplete: function(data) {
+                var address_road = data.address; // 최종 도로명 주소
+                var address_bname = data.bname? data.bname : ''; // 동 (지번주소)
+
+                // 주소 정보를 해당 필드에 넣는다.
+                document.getElementById("signupAddressRoad").value = address_road;
+                document.getElementById("signupAddressBname").value = address_bname;
+            }
+        }).open();
+    }
+
     function signUp(){
         const signupNickname = $('#signupNickname').val();
         const signupName = $('#signupName').val();
         const signupEmail = $('#signupEmail').val();
         const signupPass = $('#signupPass').val();
-        const signupAddress = $('#signupAddress').val();
+        const signupAddressRoad = $('#signupAddressRoad').val();
+        const signupAddressBname = $('#signupAddressBname').val();
         const signupPhonenumber = $('#signupPhonenumber').val();
         const signupReferralcode = $('#signupReferralcode').val();
         if (!signupNickname) {
@@ -113,9 +133,9 @@
 		alert('이메일을 입력해주세요.');
         } else if (!signupPass) {
 		alert('비밀번호를 입력해주세요.');
-        } else if (!signupAddress) {
+        } else if (!signupAddressRoad) {
 		alert('주소를 입력해주세요.');
-        } else if (!signupReferralcode) {
+        } else if (!signupPhonenumber) {
 		alert('연락처를 입력해주세요.');
         } else{
             $.ajax({
@@ -126,7 +146,8 @@
                     name: signupName,
                     email: signupEmail,
                     password: signupPass,
-                    address: signupAddress,
+                    address_road: signupAddressRoad,
+                    address_bname: signupAddressBname,
                     phone_number: signupPhonenumber,
                     referral_code: signupReferralcode
                 },


### PR DESCRIPTION
[추가] https 인증서와 개인키 발급을 위한 mkcert 라이브러리 설치

사용법(처음 한번은 꼭 해주셔야 합니다!):
    - 1. npm install -g mkcert (mkcert를 전역으로 설치)
    - 2. mkcert create-ca (CA 인증서와 개인키인 ca.crt, ca.key 파일 만들기)
    - 3. mkcert create-cert (2에서 만들어진 파일들을 기반으로 cert.key, cert.crt 파일이 만들어짐)
    - 4. 2에서 만든 두 개 파일은 따로 안전한 곳에 보관합니다. (저희 앱에서 쓰이지 않지만 비밀키이므로 보관합니다)
    - 5. 3에서 만든 두 개 파일을 src/config/ 폴더 안에 옮겨놓습니다.
    - 6. 위의 4개 파일은 .gitignore에 이미 등록시켜놨기 때문에 github에 올라가지 않을 거예요 (안전합니다!)
    - 7. 이제 서버를 실행시키면 https://localhost:3000 주소로 접속할 수 있습니다!