### PR TITLE
[수정] 자유게시판 비로그인 유저는 댓글 작성 버튼이 작동하지 않도록 변경

### DIFF
--- a/src/ejs-render/ejs-render.controller.ts
+++ b/src/ejs-render/ejs-render.controller.ts
@@ -276,7 +276,7 @@ export class EjsRenderController {
     } else {
       messages = await this.messagesService.getUnreadMessages(req.userId);
     }
-    console.log("d요거",messages)
+
     return {
       components: 'message',
       userId: req.userId,

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -22,7 +22,7 @@ export class PostsService {
     console.log('endCursor', endCursor);
     const isFirstPage = !endCursor;
     const [posts, total] = await this.postsRepository.findAndCount({
-      take: 7+1,
+      take: 7 + 1,
       where: !isFirstPage ? { post_id: LessThanOrEqual(endCursor) } : null,
       relations: {
         user: {},

--- a/src/requests/requests.service.ts
+++ b/src/requests/requests.service.ts
@@ -26,57 +26,56 @@ export class RequestsService {
   async getRequestsByCursor(endCursor?: number, take: number = 9) {
     const isFirstPage = !endCursor;
     const value = await this.cacheManager.get(`requestCursor${endCursor}`);
-    if (!value){
-    const [requests, total] = await this.requestsRepository.findAndCount({
-      take,
-      where: !isFirstPage ? { request_id: LessThan(endCursor) } : null,
-      relations: {
-        user: {
-          cats: true,
-        },
-      },
-      select: {
-        user: {
-          nickname: true,
-          address_bname: true,
-          cats: {
-            image: true,
+    if (!value) {
+      const [requests, total] = await this.requestsRepository.findAndCount({
+        take,
+        where: !isFirstPage ? { request_id: LessThan(endCursor) } : null,
+        relations: {
+          user: {
+            cats: true,
           },
         },
-        request_id: true,
-        reserved_begin_date: true,
-        reserved_end_date: true,
-        updated_at: true,
-        detail: true,
-        is_ongoing: true,
-      },
-      order: {
-        request_id: 'DESC',
-      },
-    });
+        select: {
+          user: {
+            nickname: true,
+            address_bname: true,
+            cats: {
+              image: true,
+            },
+          },
+          request_id: true,
+          reserved_begin_date: true,
+          reserved_end_date: true,
+          updated_at: true,
+          detail: true,
+          is_ongoing: true,
+        },
+        order: {
+          request_id: 'DESC',
+        },
+      });
 
-    let newEndCursor = requests[requests.length - 1]?.request_id ?? false;
-    let startCursor = requests[0]?.request_id ?? false;
-    let hasPreviousPage = total >= take;
-    let hasNextPage = hasPreviousPage ? requests.length > take : true;
+      let newEndCursor = requests[requests.length - 1]?.request_id ?? false;
+      let startCursor = requests[0]?.request_id ?? false;
+      let hasPreviousPage = total >= take;
+      let hasNextPage = hasPreviousPage ? requests.length > take : true;
 
-    const request = {
-      data: requests,
-      pageOpt: {
-        total,
-        take,
-        endCursor: newEndCursor,
-        startCursor,
-        hasNextPage,
-        hasPreviousPage,
-      },
-    };
-    await this.cacheManager.set(`requestCursor${endCursor}`, request);
+      const request = {
+        data: requests,
+        pageOpt: {
+          total,
+          take,
+          endCursor: newEndCursor,
+          startCursor,
+          hasNextPage,
+          hasPreviousPage,
+        },
+      };
+      await this.cacheManager.set(`requestCursor${endCursor}`, request);
 
-    return request
+      return request;
     }
     return value;
-    
   }
 
   // 동네명 bname과 직전 페이지의 마지막 인덱스 endCursor, 페이지당 표시할 게시글 수 take로 품앗이 목록 조회

--- a/views/boardDetail.ejs
+++ b/views/boardDetail.ejs
@@ -42,7 +42,7 @@
                     <label for="comment">댓글 입력</label>
                     <textarea class="form-control" rows="3" id="commentContent"></textarea>
                 
-                    <button id="comment-save"  class="btn btn-primary" onclick="commentSave('<%= post.post_id %>')" type="button">입력</button>
+                    <button id="comment-save"  class="btn btn-primary" onclick="commentSave(<%= post.post_id %>, <%= userId ?? false %>)" type="button">입력</button>
            
                 </div>
             </form>
@@ -76,10 +76,13 @@
         });
     }
 
-    function commentSave(postId) {
-        const commentContent = $('#commentContent').val();
-        console.log(postId);
+    function commentSave(postId, userId) {
+        if (!userId) {
+            alert('로그인 후 이용할 수 있습니다')
+            return;
+        }
 
+        const commentContent = $('#commentContent').val();
 		if (!commentContent) {
 			alert('댓글을 입력해주세요.');
 			return;

--- a/views/boardList.ejs
+++ b/views/boardList.ejs
@@ -101,7 +101,7 @@
                     <td><a href="/boardList/${post.category}">${post.category}</a></td> 
                     <th><a href='/boardDetail/${post.post_id}'>${post.title}</a></th>
                     <td>${post.user?.nickname}</td>
-                    <td>${post.created_at.toLocaleString()}</td>
+                    <td>${post.created_at.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })}</td>
                 </tr>
           `;
           const newRow = table.insertRow(table.rows.length);

--- a/views/requestList.ejs
+++ b/views/requestList.ejs
@@ -109,7 +109,7 @@
 			<% } %>
 		</div>
 
-		<button onclick="moreRequestLists(<%= requests.pageOpt.endCursor %>, <%= user?.address_certified ?? false %>)" id="moreBtn" type="button" class="btn btn-outline-secondary">더보기</button>
+		<button onclick="moreRequestLists(<%= requests.pageOpt.endCursor %>, <%= user?.address_certified ?? false %>, '<%= user?.address_bname %>')" id="moreBtn" type="button" class="btn btn-outline-secondary">더보기</button>
     
 		<br><br>
 	</div>
@@ -143,121 +143,145 @@
 		})
 	}
 
-	async function moreRequestLists(endRequestId, address_certified) {
-		if (endRequestId === -1) {
-			return;
+	async function moreRequestLists(endRequestId, address_certified, bname) {
+
+		// 비로그인 혹은 위치 인증을 마치지 않은 경우: 동네 상관 없이 전부 조회, 동네명은 가림. 
+		if (!address_certified) {
+
+			$.ajax({
+				type: 'GET',
+				async: "true",
+				url: `/requests?endCursor=${endRequestId}`,
+				success: function (response) {
+					showCards(response, address_certified, bname);
+				},
+				error: function (err) {
+					console.log(err);
+				},
+			});
+
+		// 로그인과 위치 인증을 마친 경우: 동네명으로 조회, 동네명 표시. 
+		} else {
+
+			$.ajax({
+				type: 'GET',
+				async: "true",
+				url: `/requests/${bname}?endCursor=${endRequestId}`,
+				success: function (response) {
+					showCards(response, address_certified, bname);
+				},
+				error: function (err) {
+					console.log(err);
+				},
+			});
 		}
+	}
 
-		console.log('endRequestId', endRequestId);
-		$.ajax({
-		type: 'GET',
-		async: "true",
-		url: `/requests?endCursor=${endRequestId}`,
-		success: function (response) {
-			const cardContainer = $('.request-cards-container');
-			
-			if (response.data.length === 0) {
-				const tempHTML = `<div style="margin: 10px auto;">
-					마지막 항목입니다
-					</div>
-					`
-				cardContainer.append(tempHTML);
-				// 버튼 업데이트
-				const moreButton = document.getElementById('moreBtn')
-				moreButton.setAttribute('onClick', `moreRequestLists(-1,  ${address_certified})`)
-				return;
-			}
-
-			response.data.forEach((request) => {
-				
-				const minutesAgo = (Date.now() - new Date(request.updated_at)) / 1000 / 60
-				let updated = ''
-				if (minutesAgo < 60) {
-					updated += parseInt(minutesAgo) + '분'
-				} else if (minutesAgo / 60 <= 48) {
-					updated += parseInt(minutesAgo / 60) + '시간'
-				} else {
-					updated += parseInt(minutesAgo / 60 / 24) + '일'
-				} 
-
-				let reserved_dates = ''
-				if (request.reserved_end_date == request.reserved_begin_date) {
-					reserved_dates = request.reserved_begin_date;
-				} else {
-					reserved_dates = request.reserved_begin_date + ' ~ ' + request.reserved_end_date;
-				}
-
-				let ongoing = ''
-				if (request.is_ongoing) {
-					ongoing = '모집중'
-				} else {
-					ongoing = '모집 완료'
-				}
-
-				let bname = ''
-				if (address_certified) { 
-					bname = request.user?.address_bname
-				} else {
-					bname = '동네를 인증해주세요!'
-				}
-
-				const tempHTML = `
-				<div class="col">
-					<div onclick="location.href='/request/detail/${request.request_id}'" class="card h-100" style="border-radius: 20px; cursor: pointer;">
-
-						<div class="cat-card">
-							<div class="imgContainer" style="background-image: url('${request.user?.cats[0].image}');">
-							<img src="" alt="">
-							<div class="status">
-								<p>${ongoing}</p>
-							</div>
-							</div>
-							<div class="whole-column-container">
-								<div class="cat-info-title" id="period">
-									기간
-								</div>
-								<div class="cat-info-content">
-									${reserved_dates} 
-								</div>
-							</div>
-							<div class="whole-column-container">
-								<div class="cat-info-title" id="name">
-								연락
-								</div>
-								<div class="cat-info-content">
-									${request.user?.nickname}
-								</div>
-							</div>
-							<div class="whole-column-container">
-								<div class="cat-info-title" id="character">
-									지역
-								</div>
-								<div class="cat-info-content">
-									${bname}
-								</div>
-							</div>
-							
-							<div class="more">
-								<small class="text-muted align-center">${updated} 전 업데이트</small>
-								<button class="moreBtn" onclick="location.href='/request/detail/${request.request_id}'">> 자세히 보기</button>
-							</div>
-						</div>
-					</div>
+	// 성공 응답 response와 현재 유저가 동네 인증을 했는지 address_certified를 받아 
+	// 카드 그리기와 버튼 업데이트 시전
+	function showCards(response, address_certified, bname) {
+		const cardContainer = $('.request-cards-container');
+		
+		// 되돌아온 게시글 수가 0이라면 '마지막 항목입니다' 표시 후 더보기 버튼 비활성화
+		if (response.data.length === 0) {
+			const tempHTML = `<div style="margin: 10px auto;">
+				마지막 항목입니다
 				</div>
 				`
-
-				cardContainer.append(tempHTML);
-			})
-
+			cardContainer.append(tempHTML);
 
 			// 버튼 업데이트
 			const moreButton = document.getElementById('moreBtn')
-			moreButton.setAttribute('onClick', `moreRequestLists(${response.pageOpt.endCursor}, ${address_certified})`)
-		},
-		error: function (err) {
-			console.log(err);
-		},
-    });
-  }
+			moreButton.setAttribute('disabled', '')
+			
+			return;
+		}
+
+		// 되돌아온 게시글 수만큼 카드 만들고 덧붙임
+		response.data.forEach((request) => {
+			
+			const minutesAgo = (Date.now() - new Date(request.updated_at)) / 1000 / 60
+			let updated = ''
+			if (minutesAgo < 60) {
+				updated += parseInt(minutesAgo) + '분'
+			} else if (minutesAgo / 60 <= 48) {
+				updated += parseInt(minutesAgo / 60) + '시간'
+			} else {
+				updated += parseInt(minutesAgo / 60 / 24) + '일'
+			} 
+
+			let reserved_dates = ''
+			if (request.reserved_end_date == request.reserved_begin_date) {
+				reserved_dates = request.reserved_begin_date;
+			} else {
+				reserved_dates = request.reserved_begin_date + ' ~ ' + request.reserved_end_date;
+			}
+
+			let ongoing = ''
+			if (request.is_ongoing) {
+				ongoing = '모집중'
+			} else {
+				ongoing = '모집 완료'
+			}
+
+			let bname = ''
+			if (address_certified) { 
+				bname = request.user?.address_bname
+			} else {
+				bname = '동네를 인증해주세요!'
+			}
+
+			const tempHTML = `
+			<div class="col">
+				<div onclick="location.href='/request/detail/${request.request_id}'" class="card h-100" style="border-radius: 20px; cursor: pointer;">
+
+					<div class="cat-card">
+						<div class="imgContainer" style="background-image: url('${request.user?.cats[0].image}');">
+						<img src="" alt="">
+						<div class="status">
+							<p>${ongoing}</p>
+						</div>
+						</div>
+						<div class="whole-column-container">
+							<div class="cat-info-title" id="period">
+								기간
+							</div>
+							<div class="cat-info-content">
+								${reserved_dates} 
+							</div>
+						</div>
+						<div class="whole-column-container">
+							<div class="cat-info-title" id="name">
+							연락
+							</div>
+							<div class="cat-info-content">
+								${request.user?.nickname}
+							</div>
+						</div>
+						<div class="whole-column-container">
+							<div class="cat-info-title" id="character">
+								지역
+							</div>
+							<div class="cat-info-content">
+								${bname}
+							</div>
+						</div>
+						
+						<div class="more">
+							<small class="text-muted align-center">${updated} 전 업데이트</small>
+							<button class="moreBtn" onclick="location.href='/request/detail/${request.request_id}'">> 자세히 보기</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			`
+
+			cardContainer.append(tempHTML);
+
+			// 버튼 업데이트
+			const moreButton = document.getElementById('moreBtn')
+			moreButton.setAttribute('onClick', `moreRequestLists(${response.pageOpt.endCursor}, ${address_certified}, '${bname}')`)
+		})
+	}
 	
 </script>


### PR DESCRIPTION
[수정] 품앗이 목록 '내 동네'가 아닌 다른 동네 글도 보이던 에러 수정
    - 첫 페이지를 서버 사이드 렌더링으로 그려줄 땐 동네명으로 검색하는 api로 잘 불러오나, 두 번째 페이지부터 ajax 호출로 불러올 때 동네명 따지지 않고 전부 조회하는 api를 호출해서 그려주게 되어있던 것이 원인
      => requestList.ejs의 ajax 호출을 수정. '비로그인/위치 미인증' 상태와, '위치 인증' 상태로 나누어 ajax를 호출하도록 변경함